### PR TITLE
Remove grafana admin panel credentials

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -49,6 +49,11 @@ The harness-experiments.json file makes reference to these clusters.
 vim harness/harness-clusters.json
 ```
 
+### Update grafana password
+- Navigate to newsql-benchmark/ansible/common_install_monitoring.yaml
+- Update the grafana_security section and add the following
+      admin_password: <enter_your_password>
+
 ### Run script to provision control machine. 
 Provide a unique prefix to use to name all provisioned Azure resources. Set this in an environment variable `DBEVAL_PREFIX`.
 The recommended value for this prefix is `uis-dbeval-<username>-<dbname>`
@@ -88,7 +93,7 @@ The tar archive will include the following
       
       
 *[on local machine]*
-- Open http://localhost:3000 in your browser to access grafana. Use username:admin, password:password. If port is not open, use the following command
+- Open http://localhost:3000 in your browser to access grafana. Use username:admin, password:<enter_your_password>. If port is not open, use the following command
    
 - ```export CONTROL_MACHINE_IP=`cat ansible/inventory-cm.yaml| grep '\[control\]' -A 1| tail -n1` ; ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i terraform/out/id_rsa_tf -L 3000:localhost:3000 fdb@$CONTROL_MACHINE_IP```
 - The Node exporter dashboard comes pre-installed and can be used to monitor cluster health.

--- a/ansible/common_install_monitoring.yaml
+++ b/ansible/common_install_monitoring.yaml
@@ -28,6 +28,5 @@
         datasource: 'Prometheus'
     grafana_security:
       admin_user: admin
-      admin_password: password
   tasks:
     - debug: var=node_list


### PR DESCRIPTION
Removed hardcoded  grafana admin panel credentials 

## Motivation and Context
The adobe security team's scan shows the default credentials for the grafana admin panel as a security vulnerability. Removed the default password and added a step in the INSTRUCTIONS.md file to manually set the password.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
